### PR TITLE
fix: do nothing when height is 0

### DIFF
--- a/lua/bufferlist.lua
+++ b/lua/bufferlist.lua
@@ -399,6 +399,8 @@ local function list_buffers()
 	local column = math.floor((vim.go.columns - default_opts.width) / 2)
 
 	if height == 0 then
+		-- Cleanup buffer on exit
+		api.nvim_buf_delete(scratch_buf, { force = true })
 		return
 	end
 

--- a/lua/bufferlist.lua
+++ b/lua/bufferlist.lua
@@ -398,6 +398,10 @@ local function list_buffers()
 	local row = math.floor((vim.go.lines - height) / 2)
 	local column = math.floor((vim.go.columns - default_opts.width) / 2)
 
+	if height == 0 then
+		return
+	end
+
 	local win = api.nvim_open_win(scratch_buf, true, {
 		relative = "editor",
 		width = default_opts.width,


### PR DESCRIPTION
When no buffer to list, an error of height must be a positive integer is shown. This commit prevents it by doing nothing when no buffer to list (i.e. height == 0)