### PR TITLE
feat: added option to set local win opts of BufferList window and option to have cursor start on current buffer line

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Bufferlist comes with the following defaults:
     modified = "󰝥",
   },
   win_opts = {}, -- set local vim opts of BufferList window
+  start_cursor_on_buf_line = true, -- set this to true if you want the cursor to start on the line of the currently opened buffer
   top_prompt = true, -- set this to false if you want the prompt to be at the bottom of the window instead of on top of it.
   show_path = false, -- show the relative paths the first time BufferList window is opened
 }

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Bufferlist comes with the following defaults:
     line = "▎",
     modified = "󰝥",
   },
+  win_opts = {}, -- set local vim opts of BufferList window
   top_prompt = true, -- set this to false if you want the prompt to be at the bottom of the window instead of on top of it.
   show_path = false, -- show the relative paths the first time BufferList window is opened
 }
@@ -177,6 +178,17 @@ press `keymap.toggle_path` to toggle the relative path to each buffer from the n
 
 #### Show relative path
 set `show_path` to `true` to show the relative path the first time you open the BufferList window after it has been loaded.
+
+### Adding custom window opts
+You can add custom local opts for BufferList window via `win_opts` option. `win_opts` takes a table of `key = value` items. You can see a list of available options by running `:help option-summary`, any option marked as local can be set.
+
+This example shows how to set window opts to highlight the cursor line of BufferList window:
+```lua
+win_opts = {
+    cursorline = true,
+    cursorlineopts = "line",
+},
+```
 
 ### Adding custom keymaps
 You can add custom keymaps for BufferList window via `win_keymaps` option, and keymaps for buffers via `bufs_keymaps` option

--- a/lua/bufferlist.lua
+++ b/lua/bufferlist.lua
@@ -36,6 +36,7 @@ local default_opts = {
 		save_prompt = "󰆓 ",
 	},
 	win_opts = {},
+	start_cursor_on_buf_line = true,
 	top_prompt = true,
 	show_path = false,
 }
@@ -259,8 +260,10 @@ local function list_buffers()
 	local modified_byteidx = fn.byteidx(default_opts.icons.modified, 1)
 
 	local function refresh()
+		local store_cursor_line = unpack(api.nvim_win_get_cursor(0))
 		cmd("bwipeout")
 		list_buffers()
+		fn.setcursorcharpos(store_cursor_line, 6)
 	end
 
 	for i = 1, #b do
@@ -421,7 +424,11 @@ local function list_buffers()
 	vim.wo[win].number = true
 	bo[scratch_buf].modifiable = false
 
-	fn.setcursorcharpos(1, 6)
+	if default_opts.start_cursor_on_buf_line then
+		fn.setcursorcharpos(tostring(current_buf_line or 1), 6)
+	else
+		fn.setcursorcharpos(1, 6)
+	end
 
 	for key, value in pairs(default_opts.win_opts) do
 		vim.wo[win][key] = value

--- a/lua/bufferlist.lua
+++ b/lua/bufferlist.lua
@@ -35,6 +35,7 @@ local default_opts = {
 		prompt = "",
 		save_prompt = "󰆓 ",
 	},
+	win_opts = {},
 	top_prompt = true,
 	show_path = false,
 }
@@ -421,6 +422,10 @@ local function list_buffers()
 	bo[scratch_buf].modifiable = false
 
 	fn.setcursorcharpos(1, 6)
+
+	for key, value in pairs(default_opts.win_opts) do
+		vim.wo[win][key] = value
+	end
 
 	km.set("n", default_opts.keymap.close_bufferlist, function()
 		cmd("bwipeout")


### PR DESCRIPTION
i figured adding a way to set custom local window opts of the BufferList window would be a nice way to allow for more customizability if desired, such as customizing the statuscolumn for example

as for the second thing i think it just makes more sense to have the cursor start on the line of the current buffer.  even if you don't intend to move navigate through the window with the cursor, if you were to enable vim.wo.cursorline through the win_opts option for the BufferList you would get a nicer more clear visual indicator for your current buffer (which is probably what i'll use it for).  i also added an option to disable it as well in case people who are used to the old behaviour don't want it to work like this (although it's probably an unnecessary option, if you think having it isn't worthwhile then i could always remove it)

also btw i think you did a pretty good job of designing this thing, it's definitely my favourite buffer navigator i've tried :+1: 